### PR TITLE
Stromnetz Graz has new headers format

### DIFF
--- a/docs/netzbetreiber.js
+++ b/docs/netzbetreiber.js
@@ -158,9 +158,9 @@ export const LinzAG = new Netzbetreiber("LinzAG", "Energiemenge in kWh", "Datum 
     return parseFloat(usage.replace(",", "."));
 }), ["Ersatzwert"], null, false);
 
-export const StromnetzGraz = new Netzbetreiber("StromnetzGraz", "Verbrauch Einheitstarif", "Ablesezeitpunkt", null, "parseISO", (function (usage) {
+export const StromnetzGraz = new Netzbetreiber("StromnetzGraz", "Verbrauch Gesamt - 1.8.0", "Ablesezeitpunkt", null, "parseISO", (function (usage) {
     return parseFloat(usage);
-}), ["Zaehlerstand Einheitstarif", "Zaehlerstand Hochtarif", "Zaehlerstand Niedertarif", "Verbrauch Hochtarif", "Verbrauch Niedertarif"], null, false);
+}), ["Zaehlerstand Gesamt - 1.8.0", "Verbrauch Gesamt - 1.8.0", "Status Gesamt - 1.8.0", "Zaehlerstand Hochtarif - 1.8.1", "Verbrauch Hochtarif - 1.8.1", "Status Hochtarif - 1.8.1", "Zaehlerstand Niedertarif - 1.8.2", "Verbrauch Niedertarif - 1.8.2", "Status Niedertarif - 1.8.2"], null, false);
 
 export const EnergienetzeSteiermark = new Netzbetreiber("EnergieNetzeSteiermark", "Verbrauch", "Verbrauchszeitraum Beginn", null, "dd.MM.yyyy HH:mm", (function (usage) {
     return parseFloat(usage.replace(",", "."));


### PR DESCRIPTION
Stromnetz Graz hat ein neues Exportformat:

```csv
Lieferrichtung: Bezug;;;;;;;;;
Ablesezeitpunkt;Zaehlerstand Gesamt - 1.8.0;Verbrauch Gesamt - 1.8.0;Status Gesamt - 1.8.0;Zaehlerstand Hochtarif - 1.8.1;Verbrauch Hochtarif - 1.8.1;Status Hochtarif - 1.8.1;Zaehlerstand Niedertarif - 1.8.2;Verbrauch Niedertarif - 1.8.2;Status Niedertarif - 1.8.2
2024-04-01T00:15:00.000+02:00;7902.695;0.155;VAL;;;;;;
2024-04-01T00:30:00.000+02:00;7902.828;0.133;VAL;;;;;;
2024-04-01T00:45:00.000+02:00;7902.861;0.033;VAL;;;;;;
```

Die Änderungen an den Headernamen sind natürlich trivial. Zusätzliches Problem ist aber das eine weitere Zeile `Lieferrichtung: Bezug` am Anfang eingefügt wird. Das verhindert das parsing das nur mit einer Headerzeile umgehen kann. Das zu ändern ist komplexer und bräuchte größere Umbauten.

Würde es Sinn machen z.b. eine extra Dropdownbox hinzuzufügen um manuell den Netzbetreiber auswählen können um das parsing zu vereinfachen? Kann mir auch vorstellen das es bei der automatischen Erkennung zu Konflikten kommen kann in Zukunft wenn Netzbetreiber gleiche Spaltennamen verwenden aber z.b. mit andere Einheit oder Formattierung. 