### PR TITLE
Fixed issue with price calculation of awattar neu

### DIFF
--- a/docs/tariffs.js
+++ b/docs/tariffs.js
@@ -38,7 +38,7 @@ export const awattar_neu = new Tarif (
     "+3% + 1.80ct/kWh",
     575,
     (function (price, kwh, include_monthly_fee, monthly_fee_factor) { 
-        let amount = price.plus(kwh.times(1.5)).times(1.03).times(1.2); 
+        let amount = price.times(1.03).plus(kwh.times(1.5)).times(1.2); 
         if (include_monthly_fee) amount = amount.plus(this.grundgebuehr_ct*monthly_fee_factor);
         return amount;
     })


### PR DESCRIPTION
The order how the prices are calculated is wrong.
Currently it is calculated like (spot price + 1.5 Cent) + 3% + 20% and therefore a 3% surcharge on the 1.5Cent fee is added as well. 
According to awattar price page, the 3% surcharge is only applied to the spot price but not to the additional fee.
I checked with my last invoice and after the fix, it matches the values.